### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fluent Python, the site
 
-Source code and content for [fluentpython.com](fluentpython.com).
+Source code and content for [fluentpython.com](https://fluentpython.com).
 
 
 ## References


### PR DESCRIPTION
A small fix to correctly redirect to site.

Thanks for your work on Fluent Python!